### PR TITLE
Return the full user name in user serializer

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,4 +1,4 @@
-name: Vue Lint
+name: NPM Audit
 
 on:
   pull_request:

--- a/backend/api/serializers/user.py
+++ b/backend/api/serializers/user.py
@@ -18,7 +18,7 @@ class UserSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     notifications = serializers.SerializerMethodField()
     theme = serializers.SerializerMethodField()
-    username = serializers.CharField()
+    username = serializers.SerializerMethodField()
 
     def get_avatar_url(self, obj) -> str:
         """
@@ -50,3 +50,12 @@ class UserSerializer(serializers.Serializer):
             return obj.settings.theme
         except (AttributeError, Settings.DoesNotExist):
             return 'beta'
+
+    def get_username(self, obj) -> str:
+        """
+        Use the `get_full_name` function to return the username since that actually works...
+        """
+        try:
+            return obj.get_full_name()
+        except AttributeError:
+            return 'guest'

--- a/frontend/src/components/modals/changelog.vue
+++ b/frontend/src/components/modals/changelog.vue
@@ -12,21 +12,8 @@
     </div>
     <div class="card-content content">
       <h2 class="has-text-primary subtitle">{{ version }}</h2>
-      <div class="divider"><i class="material-icons icon">expand_more</i> Deletion Update <i class="material-icons icon">expand_more</i></div>
-      <p>Wrong / Bad / Old data getting you down? Well now you can finally get rid of it!</p>
-      <p>
-        <ul>
-          <li>Characters and BIS Lists are deleted from the Character page. <span class="has-text-danger">BIS Lists cannot be deleted if they are used in a Team.</span></li>
-          <li>Teams are disbanded through the Team Settings page.</li>
-          <li>The Team Details page provides methods for Members to leave Teams, or for Team Leaders to kick Members.</li>
-        </ul>
-      </p>
-      <p>To go with this, the Team Settings page also now has the ability to regenerate an invite code for the Team. This is so kicked members are unable to get back in, if you wish.</p>
-
       <div class="divider"><i class="material-icons icon">expand_more</i> Minor Changes <i class="material-icons icon">expand_more</i></div>
-      <p>Improved visibility of links in card footers by making the default colour lighter, and all links bold.</p>
-      <p>Changed the "Add New" links on the Dashboard to be the same style as all other card footer links, instead of being buttons.</p>
-      <p>Team Details card footer links are now stored in an "Actions" dropdown due to the increasing number of them.</p>
+      <p>Fixed issue where Discord usernames were not being displayed properly.</p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
There was a weird thing with the allauth library storing usernames weirdly

`get_full_name` returns the correct Discord username